### PR TITLE
Add control framing

### DIFF
--- a/fw/rbcx-coprocessor/include/ByteFifo.hpp
+++ b/fw/rbcx-coprocessor/include/ByteFifo.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <optional>
 #include <stdint.h>
 
 /// A DMA-ready byte ring buffer with contiguous I/O API
@@ -35,6 +36,9 @@ public:
     /// Total capacity
     size_t size() const { return m_fifo.size(); }
 
+    /// True if some data is ready for reading.
+    bool hasData() const { return m_head != m_tail; }
+
     /// Override the write index aka. head
     void setHead(int newHead) {
         m_head = newHead;
@@ -59,6 +63,13 @@ public:
     /// Move the write index (head), indicating len bytes have been written.
     void notifyWritten(size_t len) {
         m_head = adjust(m_head, len);
+    }
+
+    /// Reads one byte, must be available.
+    uint8_t pop() {
+        auto value = m_fifo[m_tail];
+        m_tail = adjust(m_tail, 1);
+        return value;
     }
 
     /// Read len contiguous bytes into buffer starting at data.

--- a/fw/rbcx-coprocessor/include/ControlLink.hpp
+++ b/fw/rbcx-coprocessor/include/ControlLink.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+void secondaryUartInit();
+bool controlLinkTxReady();
+void controlLinkTxFrame(uint8_t *data, size_t len);
+size_t controlLinkRxFrame(uint8_t *data, size_t len);

--- a/fw/rbcx-coprocessor/lib/cobs-c/LICENSE.txt
+++ b/fw/rbcx-coprocessor/lib/cobs-c/LICENSE.txt
@@ -1,0 +1,22 @@
+----------------------------------------------------------------------------
+Copyright (c) 2010 Craig McQueen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+----------------------------------------------------------------------------
+

--- a/fw/rbcx-coprocessor/lib/cobs-c/README.rst
+++ b/fw/rbcx-coprocessor/lib/cobs-c/README.rst
@@ -1,0 +1,178 @@
+========================================
+Consistent Overhead Byte Stuffing (COBS)
+========================================
+
+:Author: Craig McQueen
+:Contact: http://craig.mcqueen.id.au/
+:Copyright: 2017 Craig McQueen
+
+
+C functions for encoding and decoding COBS.
+
+-----
+Intro
+-----
+
+A library is provided, which contains functions for encoding and decoding
+according to COBS methods.
+
+
+What Is COBS?
+`````````````
+
+COBS is a method of encoding a packet of bytes into a form that contains no
+bytes with value zero (0x00). The input packet of bytes can contain bytes
+in the full range of 0x00 to 0xFF. The COBS encoded packet is guaranteed to
+generate packets with bytes only in the range 0x01 to 0xFF. Thus, in a
+communication protocol, packet boundaries can be reliably delimited with 0x00
+bytes.
+
+The COBS encoding does have to increase the packet size to achieve this
+encoding. However, compared to other byte-stuffing methods, the packet size
+increase is reasonable and predictable. COBS always adds 1 byte to the
+message length. Additionally, for longer packets of length *n*, it *may* add
+n/254 (rounded down) additional bytes to the encoded packet size.
+
+For example, compare to the PPP protocol, which uses 0x7E bytes to delimit
+PPP packets. The PPP protocol uses an "escape" style of byte stuffing,
+replacing all occurences of 0x7E bytes in the packet with 0x7D 0x5E. But that
+byte-stuffing method can potentially double the size of the packet in the
+worst case. COBS uses a different method for byte-stuffing, which has a much
+more reasonable worst-case overhead.
+
+For more details about COBS, see the references [#ieeeton]_ [#ppp]_.
+
+I have included a variant on COBS, `COBS/R`_, which slightly modifies COBS to
+often avoid the +1 byte overhead of COBS. So in many cases, especially for
+smaller packets, the size of a COBS/R encoded packet is the same size as the
+original packet. See below for more details about `COBS/R`_.
+
+
+References
+``````````
+
+.. [#ieeeton]   | `Consistent Overhead Byte Stuffing`__
+                | Stuart Cheshire and Mary Baker
+                | IEEE/ACM Transations on Networking, Vol. 7, No. 2, April 1999
+
+.. __:
+.. _Consistent Overhead Byte Stuffing (for IEEE):
+    http://www.stuartcheshire.org/papers/COBSforToN.pdf
+
+.. [#ppp]       | `PPP Consistent Overhead Byte Stuffing (COBS)`_
+                | PPP Working Group Internet Draft
+                | James Carlson, IronBridge Networks
+                | Stuart Cheshire and Mary Baker, Stanford University
+                | November 1997
+
+.. _PPP Consistent Overhead Byte Stuffing (COBS):
+    http://tools.ietf.org/html/draft-ietf-pppext-cobs-00
+
+
+----------------------------
+Files and Functions Provided
+----------------------------
+
+==================  ==================  ===============================================================
+File                Short Name          Long Name
+==================  ==================  ===============================================================
+``cobs.c``          COBS                Consistent Overhead Byte Stuffing (basic method) [#ieeeton]_
+``cobsr.c``         `COBS/R`_           `Consistent Overhead Byte Stuffing--Reduced`_
+==================  ==================  ===============================================================
+
+"`Consistent Overhead Byte Stuffing--Reduced`_" (`COBS/R`_) is my own invention,
+a modification of basic COBS encoding, and is described in more detail below.
+
+The following are not implemented:
+
+==================  ======================================================================
+Short Name          Long Name
+==================  ======================================================================
+COBS/ZPE            Consistent Overhead Byte Stuffing--Zero Pair Elimination [#ieeeton]_
+COBS/ZRE            Consistent Overhead Byte Stuffing--Zero Run Elimination [#ppp]_
+==================  ======================================================================
+
+
+-------
+License
+-------
+
+The code is released under the MIT license. See LICENSE.txt for details.
+
+
+..  _COBS/R:
+..  _Consistent Overhead Byte Stuffing--Reduced:
+
+---------------------------------------------------
+Consistent Overhead Byte Stuffing--Reduced (COBS/R)
+---------------------------------------------------
+
+A modification of COBS, which I'm calling "Consistent Overhead Byte
+Stuffing--Reduced" (COBS/R), is provided in the ``cobsr.c`` file. Its
+purpose is to save one byte from the encoded form in some cases. Plain COBS
+encoding always has a +1 byte encoding overhead. See the references for
+details [#ieeeton]_. COBS/R can often avoid the +1 byte, which can be a useful
+savings if it is mostly small messages that are being encoded.
+
+In plain COBS, the last length code byte in the message has some inherent
+redundancy: if it is greater than the number of remaining bytes, this is
+detected as an error.
+
+In COBS/R, instead we opportunistically replace the final length code byte with
+the final data byte, whenever the value of the final data byte is greater than
+or equal to what the final length value would normally be. This variation can be
+unambiguously decoded: the decoder notices that the length code is greater than
+the number of remaining bytes.
+
+Examples
+````````
+
+The byte values in the examples are in hex.
+
+First example:
+
+Input:
+
+======  ======  ======  ======  ======  ======
+2F      A2      00      92      73      02
+======  ======  ======  ======  ======  ======
+
+This example is encoded the same in COBS and COBS/R. Encoded (length code bytes
+are bold):
+
+======  ======  ======  ======  ======  ======  ======
+**03**  2F      A2      **04**  92      73      02
+======  ======  ======  ======  ======  ======  ======
+
+Second example:
+
+The second example is almost the same, except the final data byte value is
+greater than what the length byte would be.
+
+Input:
+
+======  ======  ======  ======  ======  ======
+2F      A2      00      92      73      26
+======  ======  ======  ======  ======  ======
+
+Encoded in plain COBS (length code bytes are bold):
+
+======  ======  ======  ======  ======  ======  ======
+**03**  2F      A2      **04**  92      73      26
+======  ======  ======  ======  ======  ======  ======
+
+Encoded in COBS/R:
+
+======  ======  ======  ======  ======  ======
+**03**  2F      A2      **26**  92      73    
+======  ======  ======  ======  ======  ======
+
+Because the last data byte (**26**) is greater than the usual length code
+(**04**), the last data byte can be inserted in place of the length code, and
+removed from the end of the sequence. This avoids the usual +1 byte overhead of
+the COBS encoding.
+
+The decoder detects this variation on the encoding simply by detecting that the
+length code is greater than the number of remaining bytes. That situation would
+be a decoding error in regular COBS, but in COBS/R it is used to save one byte
+in the encoded message.

--- a/fw/rbcx-coprocessor/lib/cobs-c/include/cobs.h
+++ b/fw/rbcx-coprocessor/lib/cobs-c/include/cobs.h
@@ -1,0 +1,110 @@
+/*****************************************************************************
+ *
+ * cobs.h
+ *
+ * Consistent Overhead Byte Stuffing
+ *
+ ****************************************************************************/
+
+#ifndef COBS_H_
+#define COBS_H_
+
+
+/*****************************************************************************
+ * Includes
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+
+/*****************************************************************************
+ * Defines
+ ****************************************************************************/
+
+#define COBS_ENCODE_DST_BUF_LEN_MAX(SRC_LEN)            ((SRC_LEN) + (((SRC_LEN) + 253u)/254u))
+#define COBS_DECODE_DST_BUF_LEN_MAX(SRC_LEN)            (((SRC_LEN) == 0) ? 0u : ((SRC_LEN) - 1u))
+
+/*
+ * For in-place encoding, the source data must be offset in the buffer by
+ * the following amount (or more).
+ */
+#define COBS_ENCODE_SRC_OFFSET(SRC_LEN)                 (((SRC_LEN) + 253u)/254u)
+
+
+/*****************************************************************************
+ * Typedefs
+ ****************************************************************************/
+
+typedef enum
+{
+    COBS_ENCODE_OK                  = 0x00,
+    COBS_ENCODE_NULL_POINTER        = 0x01,
+    COBS_ENCODE_OUT_BUFFER_OVERFLOW = 0x02
+} cobs_encode_status;
+
+typedef struct
+{
+    size_t              out_len;
+    cobs_encode_status  status;
+} cobs_encode_result;
+
+
+typedef enum
+{
+    COBS_DECODE_OK                  = 0x00,
+    COBS_DECODE_NULL_POINTER        = 0x01,
+    COBS_DECODE_OUT_BUFFER_OVERFLOW = 0x02,
+    COBS_DECODE_ZERO_BYTE_IN_INPUT  = 0x04,
+    COBS_DECODE_INPUT_TOO_SHORT     = 0x08
+} cobs_decode_status;
+
+typedef struct
+{
+    size_t              out_len;
+    cobs_decode_status  status;
+} cobs_decode_result;
+
+
+/*****************************************************************************
+ * Function prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* COBS-encode a string of input bytes.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be encoded
+ * src_len         Length of the byte string to be encoded
+ *
+ * returns:        A struct containing the success status of the encoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobs_encode_result cobs_encode(void * dst_buf_ptr, size_t dst_buf_len,
+                               const void * src_ptr, size_t src_len);
+
+/* Decode a COBS byte string.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be decoded
+ * src_len         Length of the byte string to be decoded
+ *
+ * returns:        A struct containing the success status of the decoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobs_decode_result cobs_decode(void * dst_buf_ptr, size_t dst_buf_len,
+                               const void * src_ptr, size_t src_len);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+
+#endif /* COBS_H_ */

--- a/fw/rbcx-coprocessor/lib/cobs-c/src/cobs.c
+++ b/fw/rbcx-coprocessor/lib/cobs-c/src/cobs.c
@@ -1,0 +1,220 @@
+/*
+ * cobs.c
+ *
+ * Consistent Overhead Byte Stuffing
+ */
+
+#include <stdlib.h>
+#include "cobs.h"
+
+
+/*****************************************************************************
+ * Defines
+ ****************************************************************************/
+
+#ifndef FALSE
+#define FALSE       (0)
+#endif
+
+#ifndef TRUE
+#define TRUE        (!FALSE)
+#endif
+
+
+/*****************************************************************************
+ * Functions
+ ****************************************************************************/
+
+/* COBS-encode a string of input bytes.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be encoded
+ * src_len         Length of the byte string to be encoded
+ *
+ * returns:        A struct containing the success status of the encoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobs_encode_result cobs_encode(void * dst_buf_ptr, size_t dst_buf_len,
+                               const void * src_ptr, size_t src_len)
+{
+    cobs_encode_result  result              = { 0, COBS_ENCODE_OK };
+    const uint8_t *     src_read_ptr        = src_ptr;
+    const uint8_t *     src_end_ptr         = src_ptr + src_len;
+    uint8_t *           dst_buf_start_ptr   = dst_buf_ptr;
+    uint8_t *           dst_buf_end_ptr     = dst_buf_ptr + dst_buf_len;
+    uint8_t *           dst_code_write_ptr  = dst_buf_ptr;
+    uint8_t *           dst_write_ptr       = dst_code_write_ptr + 1;
+    uint8_t             src_byte            = 0;
+    uint8_t             search_len          = 1;
+
+
+    /* First, do a NULL pointer check and return immediately if it fails. */
+    if ((dst_buf_ptr == NULL) || (src_ptr == NULL))
+    {
+        result.status = COBS_ENCODE_NULL_POINTER;
+        return result;
+    }
+
+    if (src_len != 0)
+    {
+        /* Iterate over the source bytes */
+        for (;;)
+        {
+            /* Check for running out of output buffer space */
+            if (dst_write_ptr >= dst_buf_end_ptr)
+            {
+                result.status |= COBS_ENCODE_OUT_BUFFER_OVERFLOW;
+                break;
+            }
+
+            src_byte = *src_read_ptr++;
+            if (src_byte == 0)
+            {
+                /* We found a zero byte */
+                *dst_code_write_ptr = search_len;
+                dst_code_write_ptr = dst_write_ptr++;
+                search_len = 1;
+                if (src_read_ptr >= src_end_ptr)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                /* Copy the non-zero byte to the destination buffer */
+                *dst_write_ptr++ = src_byte;
+                search_len++;
+                if (src_read_ptr >= src_end_ptr)
+                {
+                    break;
+                }
+                if (search_len == 0xFF)
+                {
+                    /* We have a long string of non-zero bytes, so we need
+                     * to write out a length code of 0xFF. */
+                    *dst_code_write_ptr = search_len;
+                    dst_code_write_ptr = dst_write_ptr++;
+                    search_len = 1;
+                }
+            }
+        }
+    }
+
+    /* We've reached the end of the source data (or possibly run out of output buffer)
+     * Finalise the remaining output. In particular, write the code (length) byte.
+     * Update the pointer to calculate the final output length.
+     */
+    if (dst_code_write_ptr >= dst_buf_end_ptr)
+    {
+        /* We've run out of output buffer to write the code byte. */
+        result.status |= COBS_ENCODE_OUT_BUFFER_OVERFLOW;
+        dst_write_ptr = dst_buf_end_ptr;
+    }
+    else
+    {
+        /* Write the last code (length) byte. */
+        *dst_code_write_ptr = search_len;
+    }
+
+    /* Calculate the output length, from the value of dst_code_write_ptr */
+    result.out_len = dst_write_ptr - dst_buf_start_ptr;
+
+    return result;
+}
+
+
+/* Decode a COBS byte string.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be decoded
+ * src_len         Length of the byte string to be decoded
+ *
+ * returns:        A struct containing the success status of the decoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobs_decode_result cobs_decode(void * dst_buf_ptr, size_t dst_buf_len,
+                               const void * src_ptr, size_t src_len)
+{
+    cobs_decode_result  result              = { 0, COBS_DECODE_OK };
+    const uint8_t *     src_read_ptr        = src_ptr;
+    const uint8_t *     src_end_ptr         = src_ptr + src_len;
+    uint8_t *           dst_buf_start_ptr   = dst_buf_ptr;
+    uint8_t *           dst_buf_end_ptr     = dst_buf_ptr + dst_buf_len;
+    uint8_t *           dst_write_ptr       = dst_buf_ptr;
+    size_t              remaining_bytes;
+    uint8_t             src_byte;
+    uint8_t             i;
+    uint8_t             len_code;
+
+
+    /* First, do a NULL pointer check and return immediately if it fails. */
+    if ((dst_buf_ptr == NULL) || (src_ptr == NULL))
+    {
+        result.status = COBS_DECODE_NULL_POINTER;
+        return result;
+    }
+
+    if (src_len != 0)
+    {
+        for (;;)
+        {
+            len_code = *src_read_ptr++;
+            if (len_code == 0)
+            {
+                result.status |= COBS_DECODE_ZERO_BYTE_IN_INPUT;
+                break;
+            }
+            len_code--;
+
+            /* Check length code against remaining input bytes */
+            remaining_bytes = src_end_ptr - src_read_ptr;
+            if (len_code > remaining_bytes)
+            {
+                result.status |= COBS_DECODE_INPUT_TOO_SHORT;
+                len_code = remaining_bytes;
+            }
+
+            /* Check length code against remaining output buffer space */
+            remaining_bytes = dst_buf_end_ptr - dst_write_ptr;
+            if (len_code > remaining_bytes)
+            {
+                result.status |= COBS_DECODE_OUT_BUFFER_OVERFLOW;
+                len_code = remaining_bytes;
+            }
+
+            for (i = len_code; i != 0; i--)
+            {
+                src_byte = *src_read_ptr++;
+                if (src_byte == 0)
+                {
+                    result.status |= COBS_DECODE_ZERO_BYTE_IN_INPUT;
+                }
+                *dst_write_ptr++ = src_byte;
+            }
+
+            if (src_read_ptr >= src_end_ptr)
+            {
+                break;
+            }
+
+            /* Add a zero to the end */
+            if (len_code != 0xFE)
+            {
+                if (dst_write_ptr >= dst_buf_end_ptr)
+                {
+                    result.status |= COBS_DECODE_OUT_BUFFER_OVERFLOW;
+                    break;
+                }
+                *dst_write_ptr++ = 0;
+            }
+        }
+    }
+
+    result.out_len = dst_write_ptr - dst_buf_start_ptr;
+
+    return result;
+}

--- a/fw/rbcx-coprocessor/src/Bsp.hpp
+++ b/fw/rbcx-coprocessor/src/Bsp.hpp
@@ -12,12 +12,17 @@ using PinDef = std::pair<GPIO_TypeDef*, uint16_t>;
 inline const PinDef led1Pin = std::make_pair(GPIOC, 13);
 inline const PinDef usbDp = std::make_pair(GPIOA, 12);
 inline const PinDef usbDn = std::make_pair(GPIOA, 11);
+
 inline const PinDef primaryTx = std::make_pair(GPIOA, 9);
 inline const PinDef primaryRx = std::make_pair(GPIOA, 10);
-
+inline const PinDef secondaryTx = std::make_pair(GPIOA, 2);
+inline const PinDef secondaryRx = std::make_pair(GPIOA, 3);
 inline DMA_Channel_TypeDef * const primaryTxDmaChannel = DMA1_Channel4;
 inline DMA_Channel_TypeDef * const primaryRxDmaChannel = DMA1_Channel5;
 inline USART_TypeDef * const primaryUsart = USART1;
+inline DMA_Channel_TypeDef * const secondaryTxDmaChannel = DMA1_Channel7;
+inline DMA_Channel_TypeDef * const secondaryRxDmaChannel = DMA1_Channel6;
+inline USART_TypeDef * const secondaryUsart = USART2;
 
 inline void clocksInit() {
     RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
@@ -55,6 +60,7 @@ inline void clocksInit() {
     __HAL_RCC_GPIOC_CLK_ENABLE();
     __HAL_RCC_GPIOD_CLK_ENABLE();
     __HAL_RCC_USART1_CLK_ENABLE();
+    __HAL_RCC_USART2_CLK_ENABLE();
     __HAL_RCC_DMA1_CLK_ENABLE();
 }
 

--- a/fw/rbcx-coprocessor/src/ControlLink.cpp
+++ b/fw/rbcx-coprocessor/src/ControlLink.cpp
@@ -1,0 +1,107 @@
+/// Implements control frame exchange.
+/// Frame byte layout: [0x00 LEN_BYTE COBS_DATA...]
+/// COBS is used to avoid having zero bytes present on UART except as packet beginnings.
+/// https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing
+
+#include "stm32f1xx_hal.h"
+#include "stm32f1xx_hal_dma.h"
+#include "stm32f1xx_ll_usart.h"
+
+#include "Bsp.hpp"
+#include "ByteFifo.hpp"
+#include "cobs.h"
+#include <array>
+
+enum class RxState {
+    AwaitingStart,
+    AwaitingLength,
+    ReceivingFrame,
+} rxState;
+
+DMA_HandleTypeDef dmaRxHandle;
+DMA_HandleTypeDef dmaTxHandle;
+ByteFifo<512> rxFifo;
+int rxFrameLength = 0;
+int rxFrameIndex = 0;
+std::array<uint8_t, 256> rxFrameBuf;
+std::array<uint8_t, 256> txFrameBuf;
+
+void secondaryUartInit() {
+    LL_USART_InitTypeDef init;
+    LL_USART_StructInit(&init);
+    init.BaudRate = 115200;
+    init.DataWidth = LL_USART_DATAWIDTH_8B;
+    init.HardwareFlowControl = LL_USART_HWCONTROL_NONE;
+    init.Parity = LL_USART_PARITY_NONE;
+    init.StopBits = LL_USART_STOPBITS_1;
+    init.TransferDirection = LL_USART_DIRECTION_TX_RX;
+    LL_USART_Init(secondaryUsart, &init);
+    LL_USART_Enable(secondaryUsart);
+
+    // UART RX runs indefinitely in circular mode
+    dmaRxHandle.Instance = secondaryRxDmaChannel;
+    dmaRxHandle.Init.Direction = DMA_PERIPH_TO_MEMORY;
+    dmaRxHandle.Init.Mode = DMA_CIRCULAR;
+    dmaRxHandle.Init.MemInc = DMA_MINC_ENABLE;
+    dmaRxHandle.Init.PeriphInc = DMA_PINC_DISABLE;
+    dmaRxHandle.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+    dmaRxHandle.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    dmaRxHandle.Init.Priority = DMA_PRIORITY_MEDIUM;
+    HAL_DMA_Init(&dmaRxHandle);
+    HAL_DMA_Start(&dmaRxHandle, uint32_t(&(secondaryUsart->DR)), uint32_t(rxFifo.data()), rxFifo.size());
+    LL_USART_EnableDMAReq_RX(secondaryUsart);
+
+    // UART TX burst is started ad hoc each time
+    dmaTxHandle.Instance = secondaryTxDmaChannel;
+    dmaTxHandle.Init.Direction = DMA_MEMORY_TO_PERIPH;
+    dmaTxHandle.Init.Mode = DMA_NORMAL;
+    dmaTxHandle.Init.MemInc = DMA_MINC_ENABLE;
+    dmaTxHandle.Init.PeriphInc = DMA_PINC_DISABLE;
+    dmaTxHandle.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+    dmaTxHandle.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    dmaTxHandle.Init.Priority = DMA_PRIORITY_MEDIUM;
+    HAL_DMA_Init(&dmaTxHandle);
+    LL_USART_EnableDMAReq_TX(secondaryUsart);
+
+    pinInit(secondaryTx, GPIO_MODE_AF_PP, GPIO_PULLUP, GPIO_SPEED_FREQ_HIGH);
+    pinInit(secondaryRx, GPIO_MODE_AF_INPUT, GPIO_PULLUP, GPIO_SPEED_FREQ_HIGH);
+}
+
+bool controlLinkTxReady() {
+    HAL_DMA_PollForTransfer(&dmaTxHandle, HAL_DMA_FULL_TRANSFER, 0);
+    return dmaTxHandle.State == HAL_DMA_STATE_READY;
+}
+
+void controlLinkTxFrame(uint8_t* data, size_t len) {
+    assert(len <= txFrameBuf.size() - 2);
+    txFrameBuf[0] = 0x00;
+    auto encodeResult = cobs_encode(txFrameBuf.data() + 2, txFrameBuf.size() - 2, data, len);
+    txFrameBuf[1] = (uint8_t)encodeResult.out_len;
+    HAL_DMA_Start(&dmaTxHandle, uint32_t(txFrameBuf.data()), uint32_t(&secondaryUsart->DR), encodeResult.out_len + 2);
+}
+
+size_t controlLinkRxFrame(uint8_t* data, size_t len) {
+    int rxHead = rxFifo.size() - __HAL_DMA_GET_COUNTER(&dmaRxHandle);
+    rxFifo.setHead(rxHead);
+
+    while (rxFifo.hasData()) {
+        uint8_t byte = rxFifo.pop();
+
+        // Zero always initiates new frame start
+        if (byte == 0) {
+            rxState = RxState::AwaitingLength;
+        } else if (rxState == RxState::AwaitingLength) {
+            rxState = RxState::ReceivingFrame;
+            rxFrameLength = byte;
+            rxFrameIndex = 0;
+        } else if (rxState == RxState::ReceivingFrame) {
+            rxFrameBuf[rxFrameIndex++] = byte;
+            if (rxFrameIndex == rxFrameLength) {
+                rxState = RxState::AwaitingStart;
+                auto decodeResult = cobs_decode(data, len, rxFrameBuf.data(), rxFrameLength);
+                return decodeResult.out_len;
+            }
+        }
+    }
+    return 0;
+}

--- a/fw/rbcx-coprocessor/src/ControlLink.cpp
+++ b/fw/rbcx-coprocessor/src/ControlLink.cpp
@@ -16,15 +16,15 @@ enum class RxState {
     AwaitingStart,
     AwaitingLength,
     ReceivingFrame,
-} rxState;
+} static rxState;
 
-DMA_HandleTypeDef dmaRxHandle;
-DMA_HandleTypeDef dmaTxHandle;
-ByteFifo<512> rxFifo;
-int rxFrameLength = 0;
-int rxFrameIndex = 0;
-std::array<uint8_t, 256> rxFrameBuf;
-std::array<uint8_t, 256> txFrameBuf;
+static DMA_HandleTypeDef dmaRxHandle;
+static DMA_HandleTypeDef dmaTxHandle;
+static ByteFifo<512> rxFifo;
+static int rxFrameLength = 0;
+static int rxFrameIndex = 0;
+static std::array<uint8_t, 255> rxFrameBuf;
+static std::array<uint8_t, 257> txFrameBuf;
 
 void secondaryUartInit() {
     LL_USART_InitTypeDef init;
@@ -87,7 +87,7 @@ size_t controlLinkRxFrame(uint8_t* data, size_t len) {
     while (rxFifo.hasData()) {
         uint8_t byte = rxFifo.pop();
 
-        // Zero always initiates new frame start
+        // Zero always starts new frame
         if (byte == 0) {
             rxState = RxState::AwaitingLength;
         } else if (rxState == RxState::AwaitingLength) {

--- a/fw/rbcx-coprocessor/src/main.cpp
+++ b/fw/rbcx-coprocessor/src/main.cpp
@@ -1,19 +1,27 @@
 #include "stm32f1xx_hal.h"
 #include "stm32f1xx_hal_gpio.h"
 
+#include <array>
 #include "Bsp.hpp"
 #include "CdcUartTunnel.hpp"
 #include "UsbCdcLink.h"
+#include "ControlLink.hpp"
 
 int main() {
     clocksInit();
     HAL_Init();
     primaryUartInit();
+    secondaryUartInit();
     pinsInit();
     cdcLinkInit();
     while (true) {
         cdcLinkPoll();
         tunnelPoll();
+        std::array<uint8_t, 255> loopback;
+        auto len = controlLinkRxFrame(loopback.data(), loopback.size());
+        if (len && controlLinkTxReady()) {
+            controlLinkTxFrame(loopback.data(), len);
+        }
     }
 }
 


### PR DESCRIPTION
- Allocate "secondary" USART for control frame comm
- Add control frame loopback
- Use [cobs-c](https://github.com/cmcqueen/cobs-c) for COBS (to avoid zeros on the wire except frame start)

Closes #14


#### Frame format

```
0x00 0xLEN COBS-ENCODED-DATA
```

Max overall frame length is 257, COBS data limited to 255 bytes. From the nature of COBS, the first byte is wasted, therefore maximum payload is limited to **254 bytes**. There are always 3 bytes of overhead.