### PR TITLE
Řízení stupidních serv

### DIFF
--- a/fw/rbcx-coprocessor/include/StupidServoController.hpp
+++ b/fw/rbcx-coprocessor/include/StupidServoController.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "rbcx.pb.h"
+
+void stupidServoInit();
+void stupidServoDispatch(const CoprocReq_SetStupidServo& request);

--- a/fw/rbcx-coprocessor/platformio.ini
+++ b/fw/rbcx-coprocessor/platformio.ini
@@ -17,8 +17,7 @@ lib_deps =
     https://github.com/RoboticsBrno/RB3204-RBCX-coproc-comm/archive/1d756c686eea986f363655457163388a0f9ee286.zip
 
 build_type = debug
-build_unflags = -Og
-build_flags = -O0
+build_flags =
     -Iinclude
     -std=c++17
     -DUSE_FULL_LL_DRIVER

--- a/fw/rbcx-coprocessor/platformio.ini
+++ b/fw/rbcx-coprocessor/platformio.ini
@@ -14,7 +14,7 @@ platform = ststm32
 board = genericSTM32F103VC
 framework = stm32cube
 lib_deps =
-    https://github.com/RoboticsBrno/RB3204-RBCX-coproc-comm/archive/2e95894744ad45993fd29751e8f6e853ba269874.zip
+    https://github.com/RoboticsBrno/RB3204-RBCX-coproc-comm/archive/1d756c686eea986f363655457163388a0f9ee286.zip
 
 build_type = debug
 build_unflags = -Og

--- a/fw/rbcx-coprocessor/src/Dispatcher.cpp
+++ b/fw/rbcx-coprocessor/src/Dispatcher.cpp
@@ -35,6 +35,7 @@ void dispatcherPoll() {
             break;
         case CoprocReq_setStupidServo_tag:
             stupidServoDispatch(request.payload.setStupidServo);
+            break;
         }
     }
     if (xQueueReceive(statusQueue, &status, 0) == pdTRUE) {

--- a/fw/rbcx-coprocessor/src/Dispatcher.cpp
+++ b/fw/rbcx-coprocessor/src/Dispatcher.cpp
@@ -3,6 +3,7 @@
 
 #include "Bsp.hpp"
 #include "ControlLink.hpp"
+#include "StupidServoController.hpp"
 #include "queue.h"
 #include "rbcx.pb.h"
 
@@ -32,6 +33,8 @@ void dispatcherPoll() {
             status.which_payload = CoprocStat_buttonsStat_tag;
             controlLinkTx(status);
             break;
+        case CoprocReq_setStupidServo_tag:
+            stupidServoDispatch(request.payload.setStupidServo);
         }
     }
     if (xQueueReceive(statusQueue, &status, 0) == pdTRUE) {

--- a/fw/rbcx-coprocessor/src/StupidServoController.cpp
+++ b/fw/rbcx-coprocessor/src/StupidServoController.cpp
@@ -52,6 +52,16 @@ void stupidServoDispatch(const CoprocReq_SetStupidServo& request) {
     switch (request.servoIndex) {
     case 0:
         LL_TIM_OC_SetCompareCH1(servoTimer, value);
+        break;
+    case 1:
+        LL_TIM_OC_SetCompareCH2(servoTimer, value);
+        break;
+    case 2:
+        LL_TIM_OC_SetCompareCH3(servoTimer, value);
+        break;
+    case 3:
+        LL_TIM_OC_SetCompareCH4(servoTimer, value);
+        break;
     default:
         return;
     }

--- a/fw/rbcx-coprocessor/src/StupidServoController.cpp
+++ b/fw/rbcx-coprocessor/src/StupidServoController.cpp
@@ -1,0 +1,61 @@
+#include "StupidServoController.hpp"
+
+#include "Bsp.hpp"
+#include "ControlLink.hpp"
+#include "stm32f1xx_hal.h"
+#include "stm32f1xx_ll_rcc.h"
+#include "stm32f1xx_ll_tim.h"
+
+static uint32_t pwmCenterValue;
+static float pwmCoef;
+
+void stupidServoInit() {
+    LL_TIM_InitTypeDef pwmInit;
+    LL_TIM_StructInit(&pwmInit);
+    auto apb1TimClk = 2
+        * __LL_RCC_CALC_PCLK1_FREQ(SystemCoreClock, LL_RCC_GetAPB1Prescaler());
+
+    // 1/50 s :
+    pwmInit.Prescaler = 16;
+    pwmInit.Autoreload = uint32_t(apb1TimClk / 50) / pwmInit.Prescaler;
+    pwmInit.CounterMode = LL_TIM_COUNTERMODE_UP;
+    pwmInit.ClockDivision = LL_TIM_CLOCKDIVISION_DIV1;
+    pwmInit.RepetitionCounter = 0;
+
+    // Center at 1.5ms within 1/50s
+    pwmCenterValue = uint32_t(pwmInit.Autoreload * 0.075f);
+    // Range +- 0.5ms within 1/50s
+    pwmCoef = pwmInit.Autoreload * 0.025f;
+
+    LL_TIM_OC_InitTypeDef ocInit;
+    LL_TIM_OC_StructInit(&ocInit);
+    ocInit.OCMode = LL_TIM_OCMODE_PWM1;
+    ocInit.OCState = LL_TIM_OCSTATE_ENABLE;
+    ocInit.CompareValue = pwmCenterValue;
+    ocInit.OCPolarity = LL_TIM_OCPOLARITY_HIGH;
+    ocInit.OCIdleState = LL_TIM_OCIDLESTATE_LOW;
+    LL_TIM_Init(servoTimer, &pwmInit);
+
+    for (uint16_t channel = LL_TIM_CHANNEL_CH1; channel != 0; channel <<= 4) {
+        LL_TIM_OC_Init(servoTimer, channel, &ocInit);
+        LL_TIM_OC_EnablePreload(servoTimer, channel);
+    }
+    LL_TIM_SetOffStates(servoTimer, LL_TIM_OSSI_DISABLE, LL_TIM_OSSR_ENABLE);
+    LL_TIM_GenerateEvent_UPDATE(servoTimer);
+    LL_TIM_EnableAllOutputs(servoTimer);
+    LL_TIM_EnableCounter(servoTimer);
+}
+
+void stupidServoDispatch(const CoprocReq_SetStupidServo& request) {
+    uint32_t value
+        = pwmCenterValue + int32_t(pwmCoef * request.servoCmd.setPosition);
+    switch (request.servoIndex) {
+    case 0:
+        LL_TIM_OC_SetCompareCH1(servoTimer, value);
+    default:
+        return;
+    }
+    CoprocStat status;
+    status.which_payload = CoprocStat_stupidServoStat_tag;
+    controlLinkTx(status);
+}

--- a/fw/rbcx-coprocessor/src/main.cpp
+++ b/fw/rbcx-coprocessor/src/main.cpp
@@ -6,6 +6,7 @@
 #include "CdcUartTunnel.hpp"
 #include "ControlLink.hpp"
 #include "Dispatcher.hpp"
+#include "StupidServoController.hpp"
 #include "UsbCdcLink.h"
 #include <array>
 
@@ -17,6 +18,7 @@ int main() {
     controlUartInit();
     pinsInit();
     cdcLinkInit();
+    stupidServoInit();
     while (true) {
         cdcLinkPoll();
         tunnelPoll();


### PR DESCRIPTION
- [x] Přidání zpráv `CoprocReq_SetStupidServo` a spol. k řízení servo výstupů *<-1, 1>*
- [x] Přidání logiky pro enable/disable jednotlivých kanálů

Umožňuje "overdrive" serva mimo 1ms-2ms rozsah - některá serva (asi všechny) umí jít dál.