### PR TITLE
Fix CdcUartTunnel, implement ESP32 boot sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ eagle.epf
 
 # file locks introduced since 7.x
 *.lck
+
+
+.~*

--- a/fw/rbcx-coprocessor/include/Bsp.hpp
+++ b/fw/rbcx-coprocessor/include/Bsp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 /// Board Support Package maps application onto concrete pins/peripherals
 
+#include "FreeRTOSConfig.h"
 #include "stm32f1xx_hal.h"
 #include "stm32f1xx_hal_gpio.h"
 #include "stm32f1xx_ll_utils.h"
@@ -79,6 +80,12 @@ inline const PinDef servoPins = std::make_pair(GPIOA,
     servo1Pin.second | servo2Pin.second | servo3Pin.second | servo4Pin.second);
 
 inline TIM_TypeDef* const servoTimer = TIM5;
+
+inline const PinDef espEnPin = std::make_pair(GPIOC, GPIO_PIN_8);
+inline const PinDef esp0Pin = std::make_pair(GPIOC, GPIO_PIN_10);
+inline const PinDef esp2Pin = std::make_pair(GPIOC, GPIO_PIN_11);
+inline const PinDef esp12Pin = std::make_pair(GPIOB, GPIO_PIN_15);
+inline const PinDef esp15Pin = std::make_pair(GPIOB, GPIO_PIN_14);
 
 inline void clocksInit() {
     RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
@@ -210,6 +217,10 @@ inline void pinsInit() {
     // Set UART5 pins to high impedance so we can override them from pinheads
     pinInit(uart5TxPin, GPIO_MODE_OUTPUT_OD, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
     pinInit(uart5RxPin, GPIO_MODE_OUTPUT_OD, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+
+    // Configure IRQ on espEnPin pin
+    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 }
 
 inline bool isPressed(PinDef button) {

--- a/fw/rbcx-coprocessor/include/CdcUartTunnel.hpp
+++ b/fw/rbcx-coprocessor/include/CdcUartTunnel.hpp
@@ -1,4 +1,8 @@
 #pragma once
 
+#include "usb_cdc.h"
+
 void tunnelUartInit();
 void tunnelPoll();
+bool tunnelOnSetLineCoding(
+    const usb_cdc_line_coding& old, const usb_cdc_line_coding& current);

--- a/fw/rbcx-coprocessor/include/Esp32Manager.hpp
+++ b/fw/rbcx-coprocessor/include/Esp32Manager.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "utils/QueueWrapper.hpp"
+#include "utils/RingBuffer.hpp"
+#include "utils/TaskWrapper.hpp"
+
+// These methods are weakly linked as empty from Esp32Manager.cpp,
+// override them near the code which uses these pins.
+// * xxFreeUp - called when Esp32Manager needs to assume control of the pin,
+//              you can clean-up here if needed.
+// * xxRestore - called when Esp32Manager is done with the pins, you should call
+//               your pinInits here.
+void esp32Pin0FreeUp();
+void esp32Pin0Restore();
+void esp32Pin2FreeUp();
+void esp32Pin2Restore();
+void esp32Pin12FreeUp();
+void esp32Pin12Restore();
+void esp32Pin15FreeUp();
+void esp32Pin15Restore();
+
+class Esp32Manager {
+    Esp32Manager(const Esp32Manager&) = delete;
+
+public:
+    Esp32Manager() {};
+    ~Esp32Manager() {};
+
+    void init();
+
+    void queueReset(bool bootloader = false);
+
+    void onEnRising();
+    void onSerialBreak(bool dtr, bool rst);
+
+private:
+    enum NotificationType : uint32_t {
+        NtfNone = 0,
+        NtfResetNormal = (1 << 0),
+        NtfResetBootloader = (1 << 1),
+    };
+
+    struct SerialBreak {
+        TickType_t timestamp;
+        bool dtr;
+        bool rts;
+    };
+
+    void notifyExecutor(NotificationType state);
+
+    void executorTask();
+    void executeReset(bool bootloader);
+
+    TaskWrapper<1024> m_task;
+    RingBuffer<SerialBreak, 3> m_serialBreaks;
+};
+
+extern Esp32Manager sEsp32Manager;

--- a/fw/rbcx-coprocessor/include/utils/HalDma.hpp
+++ b/fw/rbcx-coprocessor/include/utils/HalDma.hpp
@@ -1,0 +1,100 @@
+
+#include "stm32f1xx_hal_dma.h"
+
+// HAL_DMA_PollForTransfer, despite its name, can't be used
+// for polling. When it hits timeout (even the 0 one), HAL_DMA_STATE_READY is set
+// into the State member, regardless of whether the transfer is actually done or not.
+// So you can't poll for whether the transfer is done. With the Poll function. What the fuck.
+//
+// This version will never set the State to HAL_DMA_STATE_READY on Timeout,
+// only on error or when it is really done.
+//
+// Countless hours were wasted because of this garbage.
+//
+// Copied from https://github.com/STMicroelectronics/STM32CubeF1/blob/441b2cbdc25aa50437a59c4bffe22b88e78942c9/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_dma.c
+inline HAL_StatusTypeDef HAL_DMA_PollForTransfer_Really(
+    DMA_HandleTypeDef* hdma, uint32_t CompleteLevel, uint32_t Timeout) {
+    uint32_t temp;
+    uint32_t tickstart = 0U;
+
+    if (HAL_DMA_STATE_BUSY != hdma->State) {
+        /* no transfer ongoing */
+        hdma->ErrorCode = HAL_DMA_ERROR_NO_XFER;
+        __HAL_UNLOCK(hdma);
+        return HAL_ERROR;
+    }
+
+    /* Polling mode not supported in circular mode */
+    if (RESET != (hdma->Instance->CCR & DMA_CCR_CIRC)) {
+        hdma->ErrorCode = HAL_DMA_ERROR_NOT_SUPPORTED;
+        return HAL_ERROR;
+    }
+
+    /* Get the level transfer complete flag */
+    if (CompleteLevel == HAL_DMA_FULL_TRANSFER) {
+        /* Transfer Complete flag */
+        temp = __HAL_DMA_GET_TC_FLAG_INDEX(hdma);
+    } else {
+        /* Half Transfer Complete flag */
+        temp = __HAL_DMA_GET_HT_FLAG_INDEX(hdma);
+    }
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    while (__HAL_DMA_GET_FLAG(hdma, temp) == RESET) {
+        if ((__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma))
+                != RESET)) {
+            /* When a DMA transfer error occurs */
+            /* A hardware clear of its EN bits is performed */
+            /* Clear all flags */
+            hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << hdma->ChannelIndex);
+
+            /* Update error code */
+            SET_BIT(hdma->ErrorCode, HAL_DMA_ERROR_TE);
+
+            /* Change the DMA state */
+            hdma->State = HAL_DMA_STATE_READY;
+
+            /* Process Unlocked */
+            __HAL_UNLOCK(hdma);
+
+            return HAL_ERROR;
+        }
+        /* Check for the Timeout */
+        if (Timeout != HAL_MAX_DELAY) {
+            if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout)) {
+                /* Update error code */
+                SET_BIT(hdma->ErrorCode, HAL_DMA_ERROR_TIMEOUT);
+
+                /* Change the DMA state */
+                // Disabled, because it makes no fucking sense.
+                //hdma->State = HAL_DMA_STATE_READY;
+
+                /* Process Unlocked */
+
+                // Don't unlock until transfer done.
+                //__HAL_UNLOCK(hdma);
+
+                return HAL_ERROR;
+            }
+        }
+    }
+
+    if (CompleteLevel == HAL_DMA_FULL_TRANSFER) {
+        /* Clear the transfer complete flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+        /* The selected Channelx EN bit is cleared (DMA is disabled and
+    all transfers are complete) */
+        hdma->State = HAL_DMA_STATE_READY;
+    } else {
+        /* Clear the half transfer complete flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+    }
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hdma);
+
+    return HAL_OK;
+}

--- a/fw/rbcx-coprocessor/include/utils/RingBuffer.hpp
+++ b/fw/rbcx-coprocessor/include/utils/RingBuffer.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <array>
+#include <stddef.h>
+
+template <typename T, size_t Size> class RingBuffer {
+    static_assert(Size > 0);
+    static_assert(std::is_trivial<T>::value);
+
+public:
+    RingBuffer()
+        : m_data {}
+        , m_head(0) {}
+
+    size_t size() const { return Size; }
+
+    void push(const T& val) {
+        m_data[m_head] = val;
+        if (++m_head == Size) {
+            m_head = 0;
+        }
+    }
+
+    const T& at(size_t idx) const { return m_data.at(convertIdx(idx)); }
+    T& at(size_t idx) { return m_data.at(convertIdx(idx)); }
+
+    const T& operator[](size_t idx) const { return at(idx); }
+    T& operator[](size_t idx) { return at(idx); }
+
+private:
+    size_t convertIdx(size_t idx) const { return (idx + m_head) % Size; }
+
+    std::array<T, Size> m_data;
+    size_t m_head;
+};

--- a/fw/rbcx-coprocessor/src/Bsp.cpp
+++ b/fw/rbcx-coprocessor/src/Bsp.cpp
@@ -1,0 +1,17 @@
+#include "Bsp.hpp"
+#include "Esp32Manager.hpp"
+
+extern "C" void EXTI9_5_IRQHandler(void) {
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_5);
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7);
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_8);
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_9);
+}
+
+extern "C" void HAL_GPIO_EXTI_Callback(uint16_t pin) {
+    if (pin == espEnPin.second) {
+        sEsp32Manager.onEnRising();
+        __HAL_GPIO_EXTI_CLEAR_IT(espEnPin.second);
+    }
+}

--- a/fw/rbcx-coprocessor/src/ControlLink.cpp
+++ b/fw/rbcx-coprocessor/src/ControlLink.cpp
@@ -11,6 +11,7 @@
 #include "stm32f1xx_ll_usart.h"
 
 #include "Bsp.hpp"
+#include "Esp32Manager.hpp"
 #include "coproc_codec.h"
 #include "coproc_link_parser.h"
 #include "rbcx.pb.h"
@@ -30,6 +31,16 @@ static std::array<uint8_t, codec.MaxFrameSize> txDmaBuf;
 static StaticMessageBuffer_t _txMessageBufStruct;
 static uint8_t _txMessageBufStorage[512];
 static MessageBufferHandle_t txMessageBuf;
+
+void esp32Pin0Restore() {
+    pinInit(
+        controlUartTxPin, GPIO_MODE_AF_PP, GPIO_PULLUP, GPIO_SPEED_FREQ_HIGH);
+}
+
+void esp32Pin2Restore() {
+    pinInit(controlUartRxPin, GPIO_MODE_AF_INPUT, GPIO_PULLUP,
+        GPIO_SPEED_FREQ_HIGH);
+}
 
 void controlUartInit() {
     LL_USART_InitTypeDef init;
@@ -73,11 +84,6 @@ void controlUartInit() {
 
     txMessageBuf = xMessageBufferCreateStatic(sizeof(_txMessageBufStorage),
         _txMessageBufStorage, &_txMessageBufStruct);
-
-    pinInit(
-        controlUartTxPin, GPIO_MODE_AF_PP, GPIO_PULLUP, GPIO_SPEED_FREQ_HIGH);
-    pinInit(controlUartRxPin, GPIO_MODE_AF_INPUT, GPIO_PULLUP,
-        GPIO_SPEED_FREQ_HIGH);
 }
 
 bool controlLinkRx(CoprocReq& incoming) {

--- a/fw/rbcx-coprocessor/src/Esp32Manager.cpp
+++ b/fw/rbcx-coprocessor/src/Esp32Manager.cpp
@@ -1,0 +1,176 @@
+#include "stm32f1xx_hal.h"
+#include "stm32f1xx_hal_gpio.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "Bsp.hpp"
+#include "utils/Debug.hpp"
+
+#include "Esp32Manager.hpp"
+
+Esp32Manager sEsp32Manager;
+
+template <void (*FreeUp)(), void (*Restore)()> class PinGuard {
+public:
+    PinGuard() { (*FreeUp)(); }
+    ~PinGuard() { (*Restore)(); }
+};
+
+#define PIN_GUARD(PIN_NUM)                                                     \
+    PinGuard<&esp32Pin##PIN_NUM##FreeUp, &esp32Pin##PIN_NUM##Restore>          \
+        _pin##PIN_NUM##guard;
+
+void __attribute__((weak)) esp32Pin0FreeUp() {}
+void __attribute__((weak)) esp32Pin0Restore() {
+    pinInit(esp0Pin, GPIO_MODE_INPUT, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+}
+void __attribute__((weak)) esp32Pin2FreeUp() {}
+void __attribute__((weak)) esp32Pin2Restore() {
+    pinInit(esp2Pin, GPIO_MODE_INPUT, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+}
+void __attribute__((weak)) esp32Pin12FreeUp() {}
+void __attribute__((weak)) esp32Pin12Restore() {
+    pinInit(esp12Pin, GPIO_MODE_INPUT, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+}
+void __attribute__((weak)) esp32Pin15FreeUp() {}
+void __attribute__((weak)) esp32Pin15Restore() {
+    pinInit(esp15Pin, GPIO_MODE_INPUT, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+}
+
+static void esp32PinENFreeUp() {
+    pinInit(espEnPin, GPIO_MODE_OUTPUT_OD, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+}
+
+static void esp32PinENRestore() {
+    pinInit(espEnPin, GPIO_MODE_IT_RISING, GPIO_PULLUP, GPIO_SPEED_FREQ_LOW);
+}
+
+void Esp32Manager::init() {
+    // Keep ESP32 in reset until we start up
+    esp32PinENFreeUp();
+    pinWrite(espEnPin, 0);
+
+    m_task.start(
+        "esp32", configMAX_PRIORITIES - 1, [this]() { executorTask(); });
+}
+
+void Esp32Manager::notifyExecutor(NotificationType state) {
+    if (isInInterrupt()) {
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        xTaskNotifyFromISR(
+            m_task.handle(), state, eSetBits, &xHigherPriorityTaskWoken);
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    } else {
+        xTaskNotify(m_task.handle(), state, eSetBits);
+    }
+}
+
+void Esp32Manager::queueReset(bool bootloader) {
+    notifyExecutor(!bootloader ? NtfResetNormal : NtfResetBootloader);
+}
+
+void Esp32Manager::executorTask() {
+    uint32_t notification = 0;
+
+    executeReset(false);
+
+    while (true) {
+        xTaskNotifyWait(0xFFFFFFFF, 0xFFFFFFFF, &notification, portMAX_DELAY);
+        if (notification & NtfResetNormal) {
+            executeReset(false);
+        } else if (notification & NtfResetBootloader) {
+            executeReset(true);
+        }
+    }
+}
+
+void Esp32Manager::executeReset(bool bootloader) {
+    PIN_GUARD(EN);
+    pinWrite(espEnPin, 0);
+
+    if (bootloader) {
+        DEBUG("Resetting ESP32 into bootloader...\n");
+    } else {
+        DEBUG("Resetting ESP32 into user app...\n");
+    }
+
+    // min 150uS to reset
+    vTaskDelay(1);
+
+    {
+        PIN_GUARD(0);
+        PIN_GUARD(2);
+        PIN_GUARD(12);
+        PIN_GUARD(15);
+
+        pinInit(esp0Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+        pinInit(
+            esp12Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+        pinInit(
+            esp15Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+
+        pinWrite(esp12Pin, 0); // 3.3v flash
+        pinWrite(esp15Pin, 1); // Do not silence bootloader messages
+
+        if (!bootloader) {
+            pinWrite(esp0Pin, 1); // normal
+        } else {
+            pinWrite(esp0Pin, 0); // bootloader
+
+            pinInit(
+                esp2Pin, GPIO_MODE_OUTPUT_PP, GPIO_NOPULL, GPIO_SPEED_FREQ_LOW);
+            pinWrite(esp2Pin, 0); // bootloader confirm
+        }
+
+        pinWrite(espEnPin, 1);
+
+        // Hold time of bootstrap pins is 1ms
+        vTaskDelay(1);
+    }
+
+    DEBUG("Reset done.\n");
+}
+
+void Esp32Manager::onEnRising() { queueReset(false); }
+
+void Esp32Manager::onSerialBreak(bool dtr, bool rts) {
+    m_serialBreaks.push(SerialBreak {
+        .timestamp = xTaskGetTickCount(),
+        .dtr = dtr,
+        .rts = rts,
+    });
+
+    // https://github.com/espressif/esptool/blob/4a1e87d290e9ba2870b4d092baf7b9ae15e4095d/esptool.py#L469
+
+    // Bootloader
+    // [   1441314][src/UsbCdcLink.c:205]: CONTROL_LINE_STATE DTR 0 RTS 1 <-- 0
+    // [   1441414][src/UsbCdcLink.c:205]: CONTROL_LINE_STATE DTR 1 RTS 1 <-- 1
+    // [   1441415][src/UsbCdcLink.c:205]: CONTROL_LINE_STATE DTR 1 RTS 0 <-- 2
+    // [   1441465][src/UsbCdcLink.c:205]: CONTROL_LINE_STATE DTR 0 RTS 0
+
+    // Reboot
+    //                                    (don't care)          DTR 0       <-- 0
+    // [    444506][src/UsbCdcLink.cpp:205]: CONTROL_LINE_STATE DTR 0 RTS 1 <-- 1
+    // [    444607][src/UsbCdcLink.cpp:205]: CONTROL_LINE_STATE DTR 0 RTS 0 <-- 2
+
+    const auto& b = m_serialBreaks;
+    if (b[0].timestamp == 0) {
+        return;
+    }
+
+    // Detect RTS High -> low between 1 and 2
+    if (!b[1].rts || b[2].rts) {
+        return;
+    }
+
+    // minimum 50ms, max 2s
+    const auto start = b[2].dtr ? b[0].timestamp : b[1].timestamp;
+    const auto diff = b[2].timestamp - start;
+    if (diff < pdMS_TO_TICKS(50) || diff > pdMS_TO_TICKS(2000)) {
+        return;
+    }
+
+    // We're resetting now. Bootloader or Normal?
+    queueReset(b[2].dtr);
+}

--- a/fw/rbcx-coprocessor/src/UsbCdcDescriptors.c
+++ b/fw/rbcx-coprocessor/src/UsbCdcDescriptors.c
@@ -1,0 +1,12 @@
+
+#include <stdint.h>
+
+#include "usb.h"
+
+const struct usb_string_descriptor lang_desc
+    = USB_ARRAY_DESC(USB_LANGID_ENG_US);
+const struct usb_string_descriptor manuf_desc_en
+    = USB_STRING_DESC("robotikabrno.cz");
+const struct usb_string_descriptor prod_desc_en = USB_STRING_DESC("RBCX");
+const struct usb_string_descriptor cdc_iface_desc_en
+    = USB_STRING_DESC("RBCX Serial");

--- a/fw/rbcx-coprocessor/src/UsbCdcLink.cpp
+++ b/fw/rbcx-coprocessor/src/UsbCdcLink.cpp
@@ -4,8 +4,17 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "Esp32Manager.hpp"
 #include "UsbCdcLink.h"
 #include "usb_cdc.h"
+#include "utils/Debug.hpp"
+
+extern "C" {
+extern const struct usb_string_descriptor lang_desc;
+extern const struct usb_string_descriptor manuf_desc_en;
+extern const struct usb_string_descriptor prod_desc_en;
+extern const struct usb_string_descriptor cdc_iface_desc_en;
+};
 
 struct cdc_config {
     struct usb_config_descriptor config;
@@ -134,14 +143,6 @@ static const struct cdc_config config_desc = {
     },
 };
 
-static const struct usb_string_descriptor lang_desc
-    = USB_ARRAY_DESC(USB_LANGID_ENG_US);
-static const struct usb_string_descriptor manuf_desc_en
-    = USB_STRING_DESC("robotikabrno.cz");
-static const struct usb_string_descriptor prod_desc_en
-    = USB_STRING_DESC("RBCX");
-static const struct usb_string_descriptor cdc_iface_desc_en
-    = USB_STRING_DESC("RBCX Serial");
 static const struct usb_string_descriptor* const dtable[] = {
     &lang_desc,
     &manuf_desc_en,
@@ -197,8 +198,13 @@ static usbd_respond cdc_control(
             == (USB_REQ_INTERFACE | USB_REQ_CLASS)
         && req->wIndex == 0) {
         switch (req->bRequest) {
-        case USB_CDC_SET_CONTROL_LINE_STATE:
+        case USB_CDC_SET_CONTROL_LINE_STATE: {
+            const bool dtr = req->wValue & 0x01;
+            const bool rts = req->wValue & 0x02;
+            //DEBUG("CONTROL_LINE_STATE DTR %d RTS %d\n", (int)dtr, (int)rts);
+            sEsp32Manager.onSerialBreak(dtr, rts);
             return usbd_ack;
+        }
         case USB_CDC_SET_LINE_CODING:
             memcpy(req->data, &cdc_line, sizeof(cdc_line));
             return usbd_ack;

--- a/fw/rbcx-coprocessor/src/main.cpp
+++ b/fw/rbcx-coprocessor/src/main.cpp
@@ -12,6 +12,7 @@
 #include "ControlLink.hpp"
 #include "DebugLink.hpp"
 #include "Dispatcher.hpp"
+#include "Esp32Manager.hpp"
 #include "StupidServoController.hpp"
 #include "UsbCdcLink.h"
 
@@ -22,10 +23,11 @@ int main() {
     HAL_Init();
     pinsInit();
     debugUartInit();
+    sEsp32Manager.init();
+    cdcLinkInit();
     dispatcherInit();
     tunnelUartInit();
     controlUartInit();
-    cdcLinkInit();
     stupidServoInit();
 
     mainTask.start("main", 1, []() {

--- a/fw/tools/looptest.py
+++ b/fw/tools/looptest.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import random
+import serial
+import sys
+import time
+import threading
+import struct
+
+TOTAL = 256*1024
+BLOCK_SIZE = 4096
+
+
+ignore = True
+
+def read_serial(port):
+    prev = 0
+
+    last = b""
+    while True:
+        data = port.read(4)
+        if ignore:
+            continue
+    
+        cur = last + data
+        while len(cur) >= 4:
+            val = struct.unpack("<I", cur[:4])[0]
+            if val % 1024 == 0:
+                print("%08x" % val)
+            if val != prev and not ignore:
+                print("Error, %08x instead of %08x" % (val, prev))
+                raise Exception()
+            prev = (val + 1) & 0xFFFFFFFF
+            cur = cur[4:]
+
+        last = cur
+
+
+if __name__ == "__main__":
+    with serial.Serial(sys.argv[1], baudrate=921600, timeout=0.5) as port:
+        threading.Thread(target=read_serial, args=(port, ), daemon=True).start()
+
+        time.sleep(1)
+        ignore = False
+        num = 0
+        start = time.monotonic()
+        for _ in range(int(TOTAL/BLOCK_SIZE)):
+            buf = b""
+            for i in range(int(BLOCK_SIZE/4)):
+                buf += struct.pack("<I", num)
+                #print("-> %08x" % num)
+                num = (num +1) & 0xFFFFFFFF
+            port.write(buf)
+            #port.flush()
+            #time.sleep(0.01)
+        
+        end = time.monotonic()
+    
+        time.sleep(1)
+        print("Duration: %ss %s KB/s %s b/s" % ((end - start), (TOTAL/1024)/(end - start), (TOTAL*8)/(end - start)))
+        print("num: %08x" % (num - 1))


### PR DESCRIPTION
S tímhle funguje programování přes tunnel, včetně nastavování rychlosti & spol.

* Tunnel testován pomoci `fw/tools/looptest.py` na 115200 a 921600 baudu, tunnel neztrácel žádná data po nejméně 10MB.
* Co se týče náhodných znaků vrácených při otevření tunnel na Linuxu zpět do STM, částečně vyřešeno tím, že zahazujeme data, pokud si je PC nevyzvedne dostatečně rychle (tj. když port není na PC otevřený). Přijde mi, že to "FTDI" co ja na ESP32 devkitu to dělá stejně.
* Programování (pouze) testováno na dvou PC, 1x na Windows a 2x na Linuxu

Closes #24